### PR TITLE
chore: update loging container

### DIFF
--- a/.github/workflows/build-and-deploy2gcp.yml
+++ b/.github/workflows/build-and-deploy2gcp.yml
@@ -36,11 +36,8 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: 22
           script: |
-            docker stop scallop-sui-indexer-testnet
             docker stop scallop-sui-indexer-mainnet
-            docker rm scallop-sui-indexer-testnet
             docker rm scallop-sui-indexer-mainnet
             docker rmi nathan7scallop/scallop-sui-indexer:latest
             docker pull nathan7scallop/scallop-sui-indexer:latest
-            docker run -d --restart unless-stopped --name scallop-sui-indexer-testnet --log-opt max-size=500m --log-opt max-file=3 --env-file /usr/local/src/envs/.prod-testnet.env nathan7scallop/scallop-sui-indexer:latest
             docker run -d --restart unless-stopped --name scallop-sui-indexer-mainnet --log-opt max-size=500m --log-opt max-file=3 --env-file /usr/local/src/envs/.prod-mainnet.env nathan7scallop/scallop-sui-indexer:latest

--- a/.github/workflows/build-and-deploy2gcp.yml
+++ b/.github/workflows/build-and-deploy2gcp.yml
@@ -42,5 +42,5 @@ jobs:
             docker rm scallop-sui-indexer-mainnet
             docker rmi nathan7scallop/scallop-sui-indexer:latest
             docker pull nathan7scallop/scallop-sui-indexer:latest
-            docker run -d --restart unless-stopped --name scallop-sui-indexer-testnet --env-file /usr/local/src/envs/.prod-testnet.env nathan7scallop/scallop-sui-indexer:latest
-            docker run -d --restart unless-stopped --name scallop-sui-indexer-mainnet --env-file /usr/local/src/envs/.prod-mainnet.env nathan7scallop/scallop-sui-indexer:latest
+            docker run -d --restart unless-stopped --name scallop-sui-indexer-testnet --log-opt max-size=500m --log-opt max-file=3 --env-file /usr/local/src/envs/.prod-testnet.env nathan7scallop/scallop-sui-indexer:latest
+            docker run -d --restart unless-stopped --name scallop-sui-indexer-mainnet --log-opt max-size=500m --log-opt max-file=3 --env-file /usr/local/src/envs/.prod-mainnet.env nathan7scallop/scallop-sui-indexer:latest


### PR DESCRIPTION
## Changelog

I added a minor update to the command for running the container, which is used to manage the maximum log file size and the maximum number of log files that can be present.

[https://docs.docker.com/config/containers/logging/local/](https://github.com/scallop-io/sui-scallop-indexer/pull/url)